### PR TITLE
Implement Burn-to-Mint Governance Token Contract

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+tests/** linguist-vendored
+vitest.config.js linguist-vendored
+* text=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+
+**/settings/Mainnet.toml
+**/settings/Testnet.toml
+.cache/**
+history.txt
+
+logs
+*.log
+npm-debug.log*
+coverage
+*.info
+costs-reports.json
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# Burn-to-Mint Governance Token
+
+A Clarity smart contract that implements a governance token with a unique burn-to-mint mechanism on the Stacks blockchain.
+
+## Overview
+
+This contract allows users to burn STX tokens to mint governance (GOV) tokens at a 1:1 ratio. The token implements the [SIP-010](https://github.com/stacksgov/sips/blob/main/sips/sip-010/sip-010-fungible-token-standard.md) fungible token standard.
+
+## Features
+
+- **Burn-to-Mint Mechanism**: Users can burn STX to mint GOV tokens
+- **Fixed Supply Cap**: Maximum supply capped at 1,000,000 GOV tokens
+- **SIP-010 Compliant**: Implements the Stacks fungible token standard
+- **1:1 Ratio**: 1 STX burned = 1 GOV token minted
+
+## Contract Functions
+
+### Read-Only Functions
+- `get-name`: Returns token name
+- `get-symbol`: Returns token symbol "GOV"
+- `get-decimals`: Returns decimal places (6)
+- `get-total-supply`: Returns current total supply
+- `get-balance`: Returns balance for given principal
+
+### Public Functions
+- `transfer`: Transfer tokens between accounts
+- `burn-to-mint`: Burn STX to mint new GOV tokens
+
+## Usage
+
+```clarity
+;; Mint 100 GOV tokens by burning 100 STX
+(contract-call? .burn-to-mint-token burn-to-mint u100)
+
+;; Transfer 50 GOV tokens
+(contract-call? .burn-to-mint-token transfer u50 tx-sender 'RECIPIENT)
+```
+
+## Error Codes
+
+- `u100`: Supply cap exceeded
+- `u101`: Invalid amount
+- `u102`: Insufficient balance
+
+## Development
+
+To deploy and test this contract:
+
+1. Clone the repository
+2. Install [Clarinet](https://github.com/hirosystems/clarinet)
+3. Run tests: `clarinet test`
+
+## License
+
+MIT License

--- a/contracts/burn-to-mint-token.clar
+++ b/contracts/burn-to-mint-token.clar
@@ -1,0 +1,57 @@
+;; ------------------------------------------------------------
+;; Burn-to-Mint Governance Token (SIP-010 compatible minimal)
+;; ------------------------------------------------------------
+;; - Users burn STX to mint GOV tokens
+;; - 1 STX burned = 1 GOV token minted
+;; - Fixed supply cap
+;; ------------------------------------------------------------
+
+(define-constant ERR-CAP (err u100))
+(define-constant ERR-AMOUNT (err u101))
+
+;; Token metadata
+(define-constant TOKEN-NAME "BurnMint Governance Token")
+(define-constant TOKEN-SYMBOL "GOV")
+(define-constant TOKEN-DECIMALS u6) ;; 1 GOV = 10^6 units
+(define-constant MAX-SUPPLY u1000000) ;; 1M tokens max
+
+;; State
+(define-data-var total-supply uint u0)
+
+(define-map balances
+  { owner: principal }
+  { amount: uint })
+
+;; ---------- SIP-010 Read-only Functions ----------
+(define-read-only (get-name) (ok TOKEN-NAME))
+(define-read-only (get-symbol) (ok TOKEN-SYMBOL))
+(define-read-only (get-decimals) (ok TOKEN-DECIMALS))
+(define-read-only (get-total-supply) (ok (var-get total-supply)))
+(define-read-only (get-balance (who principal))
+  (ok (default-to u0 (get amount (map-get? balances { owner: who })))))
+
+
+;; ---------- Transfer ----------
+(define-public (transfer (amount uint) (sender principal) (recipient principal))
+  (let ((sender-bal (default-to u0 (get amount (map-get? balances { owner: sender })))))
+    (begin
+      (asserts! (>= sender-bal amount) (err u102))
+      (map-set balances { owner: sender } { amount: (- sender-bal amount) })
+      (let ((rec-bal (default-to u0 (get amount (map-get? balances { owner: recipient })))))
+        (map-set balances { owner: recipient } { amount: (+ rec-bal amount) })
+        (ok true)))))
+
+
+;; ---------- Burn STX to Mint GOV ----------
+(define-public (burn-to-mint (amount uint))
+  (begin
+    (asserts! (> amount u0) ERR-AMOUNT)
+    (let ((new-supply (+ (var-get total-supply) amount)))
+      (asserts! (<= new-supply MAX-SUPPLY) ERR-CAP)
+      ;; Burn STX (send to blackhole address)
+      (unwrap! (stx-transfer? amount tx-sender 'SP000000000000000000002Q6VF78) ERR-AMOUNT)
+      ;; Mint GOV tokens
+      (let ((bal (default-to u0 (get amount (map-get? balances { owner: tx-sender })))))
+        (map-set balances { owner: tx-sender } { amount: (+ bal amount) })
+        (var-set total-supply new-supply)
+        (ok true)))))


### PR DESCRIPTION
Implements a new SIP-010 compliant governance token with burn-to-mint mechanics. Users can burn STX tokens to mint governance tokens (GOV) at a 1:1 ratio, with a maximum supply cap of 1M tokens.